### PR TITLE
v1.1.0 Feature movieinfo

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 var Config struct {
-	ListenAddress        string `toml:"listen_address" comment:"proxy listen address(ip:port), should NOT match upstream_server_url"`
-	UploadServiceAddress string `toml:"upload_service_address" comment:"upload service address(ip:port), where video will be truly uploaded to. \nShould be a domain:port(if needed) or ip:port(if needed) as above, \nbut with real computer ip from command like ipconfig, etc. "`
-	VideoSaveDirectory   string `toml:"video_save_dir" comment:"directory to save uploaded video"`
-	LogPath              string `toml:"log_path" comment:"log file path"`
+	ListenAddress                string `toml:"listen_address" comment:"proxy listen address(ip:port), should NOT match upstream_server_url"`
+	UploadServiceAddress         string `toml:"upload_service_address" comment:"upload service address(ip:port), where video will be truly uploaded to. \nShould be a domain:port(if needed) or ip:port(if needed) as above, \nbut with real computer ip from command like ipconfig, etc. "`
+	VideoSaveDirectory           string `toml:"video_save_dir" comment:"directory to save uploaded video"`
+	LogPath                      string `toml:"log_path" comment:"log file path"`
+	FeatureFileNameAddVideoOwner *bool  `toml:"feature_file_name_add_video_owner" comment:"whether to add video owner in the filename. \nIf true, the filename will be like 'video_owner-something_else.mp4\nExtra development on xrpc server is needed (sending IIDX00music.movieinfo request data to POST /feature/xrpcIIDXMusicMovieInfo)\nFor more info,see server/local/feature/xrpc_iidx_movieinfo.go)'."`
 }
 
 func MustParse() {
@@ -40,6 +41,8 @@ func CheckFile() {
 		Config.UploadServiceAddress = "127.0.0.1:4399"
 		Config.VideoSaveDirectory = "./video"
 		Config.LogPath = "./log.txt"
+		Config.FeatureFileNameAddVideoOwner = new(bool)
+		*Config.FeatureFileNameAddVideoOwner = false
 
 		data, err := toml.Marshal(Config)
 		if err != nil {

--- a/config/main.go
+++ b/config/main.go
@@ -11,11 +11,11 @@ import (
 )
 
 var Config struct {
-	ListenAddress                string `toml:"listen_address" comment:"proxy listen address(ip:port), should NOT match upstream_server_url"`
-	UploadServiceAddress         string `toml:"upload_service_address" comment:"upload service address(ip:port), where video will be truly uploaded to. \nShould be a domain:port(if needed) or ip:port(if needed) as above, \nbut with real computer ip from command like ipconfig, etc. "`
-	VideoSaveDirectory           string `toml:"video_save_dir" comment:"directory to save uploaded video"`
-	LogPath                      string `toml:"log_path" comment:"log file path"`
-	FeatureFileNameAddVideoOwner *bool  `toml:"feature_file_name_add_video_owner" comment:"whether to add video owner in the filename. \nIf true, the filename will be like 'video_owner-something_else.mp4\nExtra development on xrpc server is needed (sending IIDX00music.movieinfo request data to POST /feature/xrpcIIDXMusicMovieInfo)\nFor more info,see server/local/feature/xrpc_iidx_movieinfo.go)'."`
+	ListenAddress                 string `toml:"listen_address" comment:"proxy listen address(ip:port), should NOT match upstream_server_url"`
+	UploadServiceAddress          string `toml:"upload_service_address" comment:"upload service address(ip:port), where video will be truly uploaded to. \nShould be a domain:port(if needed) or ip:port(if needed) as above, \nbut with real computer ip from command like ipconfig, etc. "`
+	VideoSaveDirectory            string `toml:"video_save_dir" comment:"directory to save uploaded video"`
+	LogPath                       string `toml:"log_path" comment:"log file path"`
+	FeatureXrpcIIDXMusicMovieInfo *bool  `toml:"feature_xrpcIIDXMusicMovieInfo" comment:"whether to add video owner in the filename. \nIf true, the filename will be like 'video_owner-something_else.mp4\nExtra development on xrpc server is needed (sending IIDX00music.movieinfo request data to POST /feature/xrpcIIDXMusicMovieInfo)\nFor more info,see server/local/feature/xrpc_iidx_movieinfo.go)'."`
 }
 
 func MustParse() {
@@ -41,8 +41,8 @@ func CheckFile() {
 		Config.UploadServiceAddress = "127.0.0.1:4399"
 		Config.VideoSaveDirectory = "./video"
 		Config.LogPath = "./log.txt"
-		Config.FeatureFileNameAddVideoOwner = new(bool)
-		*Config.FeatureFileNameAddVideoOwner = false
+		Config.FeatureXrpcIIDXMusicMovieInfo = new(bool)
+		*Config.FeatureXrpcIIDXMusicMovieInfo = false
 
 		data, err := toml.Marshal(Config)
 		if err != nil {

--- a/config/main.go
+++ b/config/main.go
@@ -15,7 +15,7 @@ var Config struct {
 	UploadServiceAddress          string `toml:"upload_service_address" comment:"upload service address(ip:port), where video will be truly uploaded to. \nShould be a domain:port(if needed) or ip:port(if needed) as above, \nbut with real computer ip from command like ipconfig, etc. "`
 	VideoSaveDirectory            string `toml:"video_save_dir" comment:"directory to save uploaded video"`
 	LogPath                       string `toml:"log_path" comment:"log file path"`
-	FeatureXrpcIIDXMusicMovieInfo *bool  `toml:"feature_xrpcIIDXMusicMovieInfo" comment:"whether to add video owner in the filename. \nIf true, the filename will be like 'video_owner-something_else.mp4\nExtra development on xrpc server is needed (sending IIDX00music.movieinfo request data to POST /feature/xrpcIIDXMusicMovieInfo)\nFor more info,see server/local/feature/xrpc_iidx_movieinfo.go)'."`
+	FeatureXrpcIIDXMusicMovieInfo *bool  `toml:"feature_xrpcIIDXMusicMovieInfo" comment:"whether to add video owner in the filename. \nIf true, the filename will be like 'video_owner-something_else.mp4\nExtra development on xrpc server is needed\n\t - sending IIDX00music.movieinfo request data to POST /feature/xrpcIIDXMusicMovieInfo\nFor more info,see server/local/feature/xrpc_iidx_movieinfo.go'."`
 }
 
 func MustParse() {

--- a/local/const.go
+++ b/local/const.go
@@ -12,6 +12,7 @@ const (
 	APIPatcher = "/patcher"
 )
 
+// game-related API (WebAPI2)
 const (
 	APIMovie = "/movie"
 
@@ -22,6 +23,17 @@ const (
 	APIMovieSessionManage = APIMovieSession + "/{sid}/videos/{vid}/{operation}"
 )
 
+// dedicated movie upload entry. since you can set video upload address in
+// APIMovieSessionManage, this entry is not considered as a part of WebAPI2
 const (
 	APIDedicatedMovieUpload = "/movie-upload/{key}"
+)
+
+// feature API that exposed to potential users. these might not necessary for
+// singleplay, but useful when running on a shared arcade or you just want to
+// implement your own feature.
+const (
+	APIFeature = "/feature"
+
+	APIFeatureXrpcIIDXMovieInfo = APIFeature + "/xrpcIIDXMovieInfo"
 )

--- a/local/feature/xrpc_iidx_movieinfo.go
+++ b/local/feature/xrpc_iidx_movieinfo.go
@@ -28,7 +28,7 @@ type requestXrpcIIDXMusicMovieInfo struct {
 }
 
 // handler POST /feature/xrpcIIDXMusicMovieInfo
-// receive IIDXxx.movieinfo request data from a xrpc server, and update
+// receive IIDX00Music.movieinfo request data from a xrpc server, and update
 // player info based on session id, including iidxid.
 func FeatureXrpcIIDXMusicMovieInfo(w http.ResponseWriter, r *http.Request) {
 	// standard body read and parse process
@@ -63,7 +63,7 @@ func FeatureXrpcIIDXMusicMovieInfo(w http.ResponseWriter, r *http.Request) {
 	// update session info with video owner's unique id
 	info.VideoOwnerId = body.IIDXID
 
-	// update vession map. IIDXxxmusic.movieinfo is called before the PUT request (before begin-upload
+	// update vession map. IIDX00music.movieinfo is called before the PUT request (before begin-upload
 	// tbh). And this software is not intended to be run as a server for multiple client. Also upload
 	// is single-threaded on one machine. So there will be no race condition. As a result, this update
 	// is safe.

--- a/local/feature/xrpc_iidx_movieinfo.go
+++ b/local/feature/xrpc_iidx_movieinfo.go
@@ -62,7 +62,7 @@ func FeatureXrpcIIDXMusicMovieInfo(w http.ResponseWriter, r *http.Request) {
 			// create a new session info if not exists, because this call happens before begin-upload request.
 			session = vsession.Info{}
 		}
-		info := session.(*vsession.Info)
+		info := session.(vsession.Info)
 
 		// update session info with video owner's unique id
 		info.VideoOwnerId = body.IIDXID

--- a/local/feature/xrpc_iidx_movieinfo.go
+++ b/local/feature/xrpc_iidx_movieinfo.go
@@ -1,0 +1,77 @@
+package feature
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/bookqaq/010-record-api/logger"
+	"github.com/bookqaq/010-record-api/utils"
+	"github.com/bookqaq/010-record-api/vsession"
+)
+
+// these are data we need for xrpcIIDXMovieInfo
+type requestXrpcIIDXMusicMovieInfo struct {
+	SessionId string `json:"session_id"` // call.IIDX00Music.session_id : which session we want to update
+	IIDXID    string `json:"iidxid"`     // call.IIDX00Music.iidxid     : iidxid of the video owner next
+
+	// these are data we do not need but appears in the request. I'll write and
+	// comment them, for we don't need these.
+	// ClassId      string `json:"class_id"`
+	// CompanyCode  string `json:"company_code"`
+	// ConsumerCode string `json:"consumer_code"`
+	// LocationId   string `json:"location_id"`
+	// LocationName string `json:"location_name"`
+	// Method       string `json:"method"`
+	// MusicId      string `json:"music_id"`
+	// ProcType     string `json:"proc_type"`
+}
+
+// handler POST /feature/xrpcIIDXMusicMovieInfo
+// receive IIDXxx.movieinfo request data from a xrpc server, and update
+// player info based on session id, including iidxid.
+func FeatureXrpcIIDXMusicMovieInfo(w http.ResponseWriter, r *http.Request) {
+	// standard body read and parse process
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		logger.Error.Println("feature xrpcIIDXMusicMovieInfo failed to read body:", err)
+		utils.ResponseJSON(w, http.StatusBadRequest, map[string]any{
+			"status": 400,
+			"msg":    "can't read body",
+		})
+		return
+	}
+
+	var body requestXrpcIIDXMusicMovieInfo
+	if err := json.Unmarshal(requestBody, &body); err != nil {
+		logger.Error.Println("feature xrpcIIDXMusicMovieInfo failed to parse data:", err)
+		utils.ResponseJSON(w, http.StatusBadRequest, map[string]any{
+			"status": 400,
+			"msg":    "data parse error",
+		})
+		return
+	}
+
+	// check session exists and get session info
+	session, ok := vsession.MapInfo.Load(body.SessionId)
+	if !ok {
+		// create a new session info if not exists, because this call happens before begin-upload request.
+		session = vsession.Info{}
+	}
+	info := session.(*vsession.Info)
+
+	// update session info with video owner's unique id
+	info.VideoOwnerId = body.IIDXID
+
+	// update vession map. IIDXxxmusic.movieinfo is called before the PUT request (before begin-upload
+	// tbh). And this software is not intended to be run as a server for multiple client. Also upload
+	// is single-threaded on one machine. So there will be no race condition. As a result, this update
+	// is safe.
+	vsession.MapInfo.Store(body.SessionId, info)
+
+	// done, return success
+	utils.ResponseJSON(w, http.StatusOK, map[string]any{
+		"status": 200,
+		"msg":    "success",
+	})
+}

--- a/local/feature/xrpc_iidx_movieinfo.go
+++ b/local/feature/xrpc_iidx_movieinfo.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/bookqaq/010-record-api/config"
 	"github.com/bookqaq/010-record-api/logger"
 	"github.com/bookqaq/010-record-api/utils"
 	"github.com/bookqaq/010-record-api/vsession"
@@ -28,47 +29,50 @@ type requestXrpcIIDXMusicMovieInfo struct {
 }
 
 // handler POST /feature/xrpcIIDXMusicMovieInfo
-// receive IIDX00Music.movieinfo request data from a xrpc server, and update
+// receive IIDX00music.movieinfo request data from a xrpc server, and update
 // player info based on session id, including iidxid.
 func FeatureXrpcIIDXMusicMovieInfo(w http.ResponseWriter, r *http.Request) {
-	// standard body read and parse process
-	requestBody, err := io.ReadAll(r.Body)
-	if err != nil {
-		logger.Error.Println("feature xrpcIIDXMusicMovieInfo failed to read body:", err)
-		utils.ResponseJSON(w, http.StatusBadRequest, map[string]any{
-			"status": 400,
-			"msg":    "can't read body",
-		})
-		return
+	// only receive additional info when
+	if config.Config.FeatureXrpcIIDXMusicMovieInfo != nil && *config.Config.FeatureXrpcIIDXMusicMovieInfo {
+		// standard body read and parse process
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			logger.Error.Println("feature xrpcIIDXMusicMovieInfo failed to read body:", err)
+			utils.ResponseJSON(w, http.StatusBadRequest, map[string]any{
+				"status": 400,
+				"msg":    "can't read body",
+			})
+			return
+		}
+		logger.Debug.Printf("feature XrpcIIDXMusicMovieInfo receive body: %s", requestBody)
+
+		var body requestXrpcIIDXMusicMovieInfo
+		if err := json.Unmarshal(requestBody, &body); err != nil {
+			logger.Error.Println("feature xrpcIIDXMusicMovieInfo failed to parse data:", err)
+			utils.ResponseJSON(w, http.StatusBadRequest, map[string]any{
+				"status": 400,
+				"msg":    "data parse error",
+			})
+			return
+		}
+
+		// check session exists and get session info
+		session, ok := vsession.MapInfo.Load(body.SessionId)
+		if !ok {
+			// create a new session info if not exists, because this call happens before begin-upload request.
+			session = vsession.Info{}
+		}
+		info := session.(*vsession.Info)
+
+		// update session info with video owner's unique id
+		info.VideoOwnerId = body.IIDXID
+
+		// update vession map. IIDX00music.movieinfo is called before the PUT request (before begin-upload
+		// tbh). And this software is not intended to be run as a server for multiple client. Also upload
+		// is single-threaded on one machine. So there will be no race condition. As a result, this update
+		// is safe.
+		vsession.MapInfo.Store(body.SessionId, info)
 	}
-
-	var body requestXrpcIIDXMusicMovieInfo
-	if err := json.Unmarshal(requestBody, &body); err != nil {
-		logger.Error.Println("feature xrpcIIDXMusicMovieInfo failed to parse data:", err)
-		utils.ResponseJSON(w, http.StatusBadRequest, map[string]any{
-			"status": 400,
-			"msg":    "data parse error",
-		})
-		return
-	}
-
-	// check session exists and get session info
-	session, ok := vsession.MapInfo.Load(body.SessionId)
-	if !ok {
-		// create a new session info if not exists, because this call happens before begin-upload request.
-		session = vsession.Info{}
-	}
-	info := session.(*vsession.Info)
-
-	// update session info with video owner's unique id
-	info.VideoOwnerId = body.IIDXID
-
-	// update vession map. IIDX00music.movieinfo is called before the PUT request (before begin-upload
-	// tbh). And this software is not intended to be run as a server for multiple client. Also upload
-	// is single-threaded on one machine. So there will be no race condition. As a result, this update
-	// is safe.
-	vsession.MapInfo.Store(body.SessionId, info)
-
 	// done, return success
 	utils.ResponseJSON(w, http.StatusOK, map[string]any{
 		"status": 200,

--- a/local/handler.go
+++ b/local/handler.go
@@ -48,12 +48,14 @@ func MovieSessionNew(w http.ResponseWriter, r *http.Request) {
 // handler POST /movie/sessions/{sid}/videos/{vid}/{operation}
 func MovieUploadManagement(w http.ResponseWriter, r *http.Request) {
 	session := r.PathValue("sid")
-	// vid := r.PathValue("vid") vid is not nessary (1.1.0+)
+	vid := r.PathValue("vid") // vid is not nessary because upload is usually single-threaded (1.1.0+)
 	operation := r.PathValue("operation")
 
 	// updated in 1.1.0, use session_id only as key, there are no video upload
 	// parallelization in a single session, so vid is not needed.
 	key := session
+
+	logger.Debug.Printf("MovieUploadManagement session: %s vid: %s operation: %s", session, vid, operation)
 
 	switch operation {
 	case constUploadStatusBegin:
@@ -155,7 +157,9 @@ func MovieUploadContext(w http.ResponseWriter, r *http.Request) {
 	// use keyinfo to generate filename
 	info := res.(vsession.Info)
 	filename := info.ToFileName()
-	if config.Config.FeatureFileNameAddVideoOwner != nil && *config.Config.FeatureFileNameAddVideoOwner {
+
+	// only generate filename with owner info if configuration is enabled
+	if config.Config.FeatureXrpcIIDXMusicMovieInfo != nil && *config.Config.FeatureXrpcIIDXMusicMovieInfo {
 		filename = info.ToFileNameWithOwner()
 	}
 	logger.Warning.Println("receive video upload request:", filename)

--- a/local/main.go
+++ b/local/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bookqaq/010-record-api/config"
+	"github.com/bookqaq/010-record-api/local/feature"
 	"github.com/bookqaq/010-record-api/utils"
 )
 
@@ -26,6 +27,10 @@ func New() http.Handler {
 	// handler for embedded web patcher, refer to MustGetPatcher() for routing details
 	local.Handle(APIPatcher+"/", http.FileServerFS(MustGetPatcher()))
 
+	// handler for feature api, for example receive some xrpc request data(1.1.0+)
+	// refer to github.com/bookqaq/010-record-api/local/feature
+	initRouterGroupFeature(local)
+
 	return local
 }
 
@@ -33,4 +38,8 @@ func initRouterGroupMovie(group *http.ServeMux) {
 	group.HandleFunc(utils.RequestURL(http.MethodGet, APIServerStatus), MovieServerStatus)
 	group.HandleFunc(utils.RequestURL(http.MethodPost, APIMovieSessionNew), MovieSessionNew)
 	group.HandleFunc(utils.RequestURL(http.MethodPost, APIMovieSessionManage), MovieUploadManagement)
+}
+
+func initRouterGroupFeature(group *http.ServeMux) {
+	group.HandleFunc(utils.RequestURL(http.MethodPost, APIFeatureXrpcIIDXMovieInfo), feature.FeatureXrpcIIDXMusicMovieInfo)
 }

--- a/vsession/helper.go
+++ b/vsession/helper.go
@@ -11,6 +11,9 @@ func GetNewUploadURL(key string) string {
 	return fmt.Sprintf("http://%s/movie-upload/%s", config.Config.UploadServiceAddress, key)
 }
 
+// GetKey returns a key for an upload session.
+//
+// Deprecated: it's not necessary for session key to contain video upload counter vid.
 func GetKey(session, id string) string {
 	return fmt.Sprintf("%s-%s", session, id)
 }

--- a/vsession/session.go
+++ b/vsession/session.go
@@ -28,5 +28,9 @@ func (info *Info) ToFileName() string {
 func (info *Info) ToFileNameWithOwner() string {
 	// TODO: option to get music name from given music_data.bin
 	localTime := time.Unix(info.Timestamp, 0).Local().Format("20060102-150405")
-	return fmt.Sprintf("%s-%s-%s-%d-%s", info.VideoOwnerId, info.VideoOwnerName, localTime, info.MusicId, info.MD5Sum)
+	videoOwnerId := info.VideoOwnerId
+	if videoOwnerId == "" {
+		videoOwnerId = "null"
+	}
+	return fmt.Sprintf("%s-%s-%s-%d-%s", info.VideoOwnerName, info.VideoOwnerId, localTime, info.MusicId, info.MD5Sum)
 }

--- a/vsession/session.go
+++ b/vsession/session.go
@@ -10,10 +10,12 @@ import (
 var MapInfo *sync.Map = new(sync.Map)
 
 type Info struct {
-	ShopName  string
-	MD5Sum    string
-	MusicId   int // id in music_data.bin
-	Timestamp int64
+	ShopName       string
+	MD5Sum         string
+	MusicId        int // id in music_data.bin. does anyone want a music_data.bin parser plus a song mapper?
+	Timestamp      int64
+	VideoOwnerId   string // optional. video owner's id, for example 8-digit iidxid.
+	VideoOwnerName string // optional. video owner's name, this is not considered unique, but adding this makes file more disguishable.
 }
 
 // info to filename
@@ -21,4 +23,10 @@ func (info *Info) ToFileName() string {
 	// TODO: option to get music name from given music_data.bin
 	localTime := time.Unix(info.Timestamp, 0).Local().Format("20060102-150405")
 	return fmt.Sprintf("%s-%d-%s", localTime, info.MusicId, info.MD5Sum)
+}
+
+func (info *Info) ToFileNameWithOwner() string {
+	// TODO: option to get music name from given music_data.bin
+	localTime := time.Unix(info.Timestamp, 0).Local().Format("20060102-150405")
+	return fmt.Sprintf("%s-%s-%s-%d-%s", info.VideoOwnerId, info.VideoOwnerName, localTime, info.MusicId, info.MD5Sum)
 }


### PR DESCRIPTION
I add movieinfo feature in v1.1.0. It aims to add accurate player info to filename. When enable, video file will be marked with player name and its unique index. Any game instance operator could use the filename to manage player's video uploaded better (maybe).